### PR TITLE
Fix docs building failure

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,5 +12,4 @@ python:
   version: 3.7
   install:
     - requirements: docs/requirements.txt
-    - requirements: docs/requirements2.txt
   system_packages: true

--- a/demuxEM/__init__.py
+++ b/demuxEM/__init__.py
@@ -16,5 +16,5 @@ from importlib_metadata import version, PackageNotFoundError
 try:
     __version__ = version(__name__)
     del version
-except PackagteNotFoundError:
+except PackageNotFoundError:
     pass

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,8 +2,6 @@ sphinx>=2.0.1
 sphinx_rtd_theme>=0.3.1
 sphinx-autodoc-typehints
 scikit-learn>=0.21.3
-natsort
+matplotlib
 seaborn
-joblib
-Cython
 pegasusio

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ natsort
 seaborn
 joblib
 Cython
+pegasusio

--- a/docs/requirements2.txt
+++ b/docs/requirements2.txt
@@ -1,1 +1,0 @@
-pegasusio

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ requires = [
     "scipy",
     "scikit-learn",
     "seaborn",
-    "pegasusio"
+    "importlib-metadata",
+    "pegasusio",
 ]
 
 setup(


### PR DESCRIPTION
* No need to seperate `pegasusio` from other dependencies.
* Remove unnecessary dependencies from `docs/requirements.txt`.
* Fix bug in `demuxEM/__init__.py`.