### PR TITLE
filter cells with 0 hashing sum

### DIFF
--- a/demuxEM/pipeline/pipeline.py
+++ b/demuxEM/pipeline/pipeline.py
@@ -32,6 +32,11 @@ def run_pipeline(input_rna_file, input_hto_file, output_name, **kwargs):
     )
     rna_data._inplace_subset_obs(obs_index)
 
+    # Filter the Hashing matrix
+    hashing_data.obs["n_counts"] = hashing_data.X.sum(axis=1).A1
+    obs_index = hashing_data.obs["n_counts"] >= 1
+    hashing_data._inplace_subset_obs(obs_index)
+
     # run demuxEM
     estimate_background_probs(hashing_data, random_state=kwargs["random_state"])
 


### PR DESCRIPTION
This fixes the error described in issue #4 and pull request #3

After this pull request, demuxEM will no longer fail when the input hashing matrix has any cells with 0 counts.