### PR TITLE
Fix bug when input multi-modal object contains non-RNA modality data

### DIFF
--- a/demuxEM/commands/DemuxEM.py
+++ b/demuxEM/commands/DemuxEM.py
@@ -13,7 +13,7 @@ Usage:
 
 Arguments:
   input_raw_gene_bc_matrices_h5           Input raw RNA expression matrix in 10x hdf5 format.
-  input_hto_csv_file                      Input HTO (antibody tag) count matrix in CSV format.
+  input_hto_csv_file                      Input HTO (antibody tag) count matrix in CSV format, with antibody names being rows and cell barcodes being columns. NOTICE: The first column (i.e. antibody names) MUST have a header name, usually "Antibody", to get correct demultiplexing results.
   output_name                             Output name. All outputs will use it as the prefix.
 
 Options:

--- a/demuxEM/pipeline/pipeline.py
+++ b/demuxEM/pipeline/pipeline.py
@@ -11,6 +11,7 @@ from demuxEM.tools import *
 def run_pipeline(input_rna_file, input_hto_file, output_name, **kwargs):
     # load input rna data
     data = io.read_input(input_rna_file, genome=kwargs["genome"], modality="rna")
+    data.subset_data(modality_subset=['rna'])
     data.concat_data() # in case of multi-organism mixing data
     genome = data.uns["genome"]
 

--- a/demuxEM/tools/demuxEM.py
+++ b/demuxEM/tools/demuxEM.py
@@ -267,6 +267,7 @@ def attach_demux_results(input_rna_file: str, rna_data: UnimodalData) -> Multimo
     >>> data = attach_demux_results('raw_data.h5', rna_data)
     """
     demux_results = read_input(input_rna_file)
+    demux_results.subset_data(modality_subset=['rna'])
     # Assume all matrices are of the same dimension
     assert demux_results.uns["modality"] == "rna"
     barcodes = demux_results.obs_names

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,15 +23,15 @@ import demuxEM
 # -- Project information -----------------------------------------------------
 
 project = "demuxEM"
-copyright = "2020 The Broad Institute, Inc. and The General Hospital Corporation. All rights reserved."
+copyright = "2020 - 2021 The Broad Institute, Inc. and The General Hospital Corporation. All rights reserved."
 author = (
     "Bo Li, Yiming Yang, and Josh Gould"
 )
 
 # The short X.Y version
-version = "0.1.0"
+version = "0.1"
 # The full version, including alpha/beta/rc tags
-release = "0.1.0"
+release = "0.1.6"
 
 
 # -- General configuration ---------------------------------------------------
@@ -209,5 +209,3 @@ texinfo_documents = [
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
-
-

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,3 +1,8 @@
+Version 0.1.6 `May 28, 2021`
+------------------------------
+
+Fix the bug when the input multi-modal object contains non-RNA modality data.
+
 Version 0.1.5 `September 16, 2020`
 ----------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requires = [
     "scikit-learn",
     "seaborn",
     "importlib-metadata >=0.7; python_version < '3.8'",
-    "pegasusio",
+    "pegasusio >=0.2.12",
 ]
 
 setup(


### PR DESCRIPTION
* Fix the bug when the input multi-modal object contains non-RNA modality data.
* Add the description on the input HTO csv file format to the documentation, with regards to Issue #9 .